### PR TITLE
Ci/release commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,17 +74,19 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4 
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          cache: npm  
+          cache: npm
           node-version: lts/*
       - name: Install dependencies
-        run: npm ci --no-optional   
+        run: npm ci --no-optional
       - name: Perform Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
           PUBLIC_REPO: ${{ secrets.PUBLIC_REPO }}
         run: npx semantic-release
         # TODO(DP): 

--- a/repo.xml
+++ b/repo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<meta xmlns="http://exist-db.org/xquery/repo" commit-id="eb9b24174fdcc1a02b3949529c5c35a3401f4a1f" commit-time="1739451461">
+<meta xmlns="http://exist-db.org/xquery/repo" commit-id="be3f565b03f8351e9d29f0ea1342a1f2295bc640" commit-time="1739480697">
     <description>Subject Taxonomy of the History of U.S. Foreign Relations (data)</description>
     <author>Office of the Historian</author>
     <website>https://history.state.gov</website>


### PR DESCRIPTION
The git plugin of semantic-release, that should push the changed `expath-pkg.xml` and `repo.xml` back to the repository did fail because of branch protection rules in place.

More info: https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/github-actions.md#pushing-packagejson-changes-to-your-repository