### PR TITLE
ci: only commit repo.xml on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,13 +60,6 @@ jobs:
       - name: lint commit message
         uses: wagoid/commitlint-github-action@v6
 
-      # Commit repo.xml file
-      - name: Commit and Push
-        if: ${{ matrix.java-version == 17 && github.event_name == 'push' && github.ref != 'refs/heads/master' }}
-        uses: actions-x/commit@v6
-        with:
-          message: "fix(repo.xml): update [skip ci]"
-
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@
 
 name: exist-db CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,16 +11,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-       fail-fast: false
-       matrix:
+      fail-fast: false
+      matrix:
         # 7.0.0-SNAPSHOT and 6.2.1 created
-         exist-version: [latest, release]
-         java-version: [11, 17]
-         exclude:
-           - exist-version: release
-             java-version: 17
-           - exist-version: latest
-             java-version: 11
+        exist-version: [latest, release]
+        java-version: [11, 17]
+        exclude:
+          - exist-version: release
+            java-version: 17
+          - exist-version: latest
+            java-version: 11
 
     steps:
       # Checkout code
@@ -36,7 +36,7 @@ jobs:
           xmllint --noout \
             $(find . -type f -name '*.xml')
 
-      # Build 
+      # Build
       - name: Build Expath Package
         uses: actions/setup-java@v4
         with:
@@ -52,7 +52,7 @@ jobs:
           duncdrum/existdb:${{ matrix.exist-version }}
           sleep 10s
 
-      # Test       
+      # Test
       - name: Run test
         run: bats --tap test/*.bats
 
@@ -87,8 +87,4 @@ jobs:
       - name: Perform Release
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
-          PUBLIC_REPO: ${{ secrets.PUBLIC_REPO }}
         run: npx semantic-release
-        # TODO(DP): 
-        #   - add secrets to github
-        #   - publish to public repo?

--- a/.releaserc
+++ b/.releaserc
@@ -1,12 +1,8 @@
 {
-  "branches": ["master"],  
+  "branches": ["master"],
   "plugins": [
     ["@semantic-release/commit-analyzer", {
-      "preset": "conventionalcommits",
-      "presetConfig": "./conventionalcommits.config.cjs",
-      "releaseRules": [
-        { "type": "!(fix|feat|build|chore|ci|docs|style|refactor|perf|test)", "release": "patch" }
-      ]
+      "preset": "conventionalcommits"
     }],
     ["@semantic-release/release-notes-generator", {
       "preset": "conventionalcommits"


### PR DESCRIPTION
Instead of _always_ pushing a changed repo.xml on any push it is deferred to releases. Constantly committing these changes has two negative side effects:
1. cluttered commit history
2. branches are changed and can not easily be amended

If a changed repo.xml is needed in a branch other than the main branch then this can be achieved by manually running

```
ant -Dapp.version=1.2.3-specialversion
```

and committing the result to that branch.

This will in turn incentivise that such test-commits be removed before they get merged to the main branch. 